### PR TITLE
actions: Don't let GitHub disable workflows...

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ x64 ]
   schedule:
-    - cron: "0 0 1 */3 *"
+    - cron: "30 0 1 */3 *"
 
 jobs:
   build:

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,21 @@
+name: Workflow Keep Alive
+
+on:
+  schedule:
+    # run once a month on the first day of the month at 00:20 UTC
+    - cron: '20 0 1 * *'
+  workflow_dispatch: {}
+
+jobs:
+  keepalive:
+    name: GitHub Workflow Immortality
+
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - name: Keep cronjob based triggers of GitHub workflows alive
+        uses: PhrozenByte/gh-workflow-immortality@v1
+        with:
+          secret: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repos: ${{ github.repository }}


### PR DESCRIPTION
Apparently inactive repositories get their automated workflows disabled, that's _bad_

Add another workflow that just keeps flicking the switch on, and update the original workflow to run ten minutes after flicking said switch back on.