### PR TITLE
Sunset the x64 branch.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,12 +1,7 @@
 name: SteamWorks.ext Build
 
 on:
-  push:
-    branches: [ x64 ]
-  pull_request:
-    branches: [ x64 ]
-  schedule:
-    - cron: "30 0 1 */3 *"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,9 +1,6 @@
 name: Workflow Keep Alive
 
 on:
-  schedule:
-    # run once a month on the first day of the month at 00:20 UTC
-    - cron: '20 0 1 * *'
   workflow_dispatch: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Exposing SteamWorks functions to SourcePawn, 64-bit edition.
 
+> [!WARNING]
+> This branch is no longer supported! Use the `universal` branch instead.
+
 ## How to get a build
 
 Click on the Actions tab above, this will take you to a list of builds.


### PR DESCRIPTION
There's no point in keeping this branch if we're building for both 32-bit and 64-bit SourceMod/SRCDS.